### PR TITLE
Adds support for window.storage event. Close #10.

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ $preferences // read value with automatic subscription
 
 ## TODO
 
-- [ ] Support changes that happen in a different tab using `window.onstorage` event
+- [X] Support changes that happen in a different tab using `window.onstorage` event. Added in #11.
 - [ ] Consider supporting multiple stores using the same key
 
 ## License

--- a/test/localStorageStore.test.ts
+++ b/test/localStorageStore.test.ts
@@ -1,6 +1,5 @@
 import { writable } from '../src/index'
 import { get } from 'svelte/store'
-// import { writable } from 'svelte/store'
 
 beforeEach(() => localStorage.clear())
 
@@ -68,7 +67,7 @@ describe('writable()', () => {
   describe('subscribe()', () => {
     it('publishes updates', () => {
       const store = writable('myKey', 123)
-      const values: number[] = [] 
+      const values: number[] = []
       const unsub = store.subscribe((value : number) => {
         if (value !== undefined) values.push(value)
       })
@@ -76,6 +75,75 @@ describe('writable()', () => {
       store.set(999)
 
       expect(values).toEqual([123, 456, 999])
+
+      unsub()
+    })
+  })
+
+  describe('handles window.storage event', () => {
+    type NumberDict = { [key: string] : number }
+
+    it('sets storage when key matches', () => {
+      const store = writable('myKey', {a: 1})
+      const values: NumberDict[] = []
+
+      const unsub = store.subscribe((value: NumberDict) => {
+        values.push(value)
+      })
+
+      const event = new StorageEvent('storage', {key: 'myKey', newValue: '{"a": 1, "b": 2}'})
+      window.dispatchEvent(event)
+
+      expect(values).toEqual([{a: 1}, {a: 1, b: 2}])
+
+      unsub()
+    })
+
+    it('sets store to null when value is null', () => {
+      const store = writable('myKey', {a: 1})
+      const values: NumberDict[] = []
+
+      const unsub = store.subscribe((value: NumberDict) => {
+        values.push(value)
+      })
+
+      const event = new StorageEvent('storage', {key: 'myKey', newValue: null})
+      window.dispatchEvent(event)
+
+      expect(values).toEqual([{a: 1}, null])
+
+      unsub()
+    })
+
+    it("doesn't update store when key doesn't match", () => {
+      const store = writable('myKey', 1)
+      const values: number[] = []
+
+      const unsub = store.subscribe((value: number) => {
+        values.push(value)
+      })
+
+      const event = new StorageEvent('storage', {key: 'unknownKey', newValue: '2'})
+      window.dispatchEvent(event)
+
+      expect(values).toEqual([1])
+
+      unsub()
+    })
+
+    it("doesn't update store when there are no subscribers", () => {
+      const store = writable('myKey', 1)
+      const values: number[] = []
+
+      const event = new StorageEvent('storage', {key: 'myKey', newValue: '2'})
+      window.dispatchEvent(event)
+      localStorage.setItem('myKey', '2')
+
+      const unsub = store.subscribe((value: number) => {
+        values.push(value)
+      })
+
+      expect(values).toEqual([2])
 
       unsub()
     })


### PR DESCRIPTION
Makes it possible to synchronize stores across multiple browser tabs.