### PR TITLE
Also check for window

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -16,7 +16,7 @@ interface Options<T> {
 }
 
 export function writable<T>(key: string, initialValue: T, options?: Options<T>): Writable<T> {
-  const browser = typeof(localStorage) != 'undefined'
+  const browser = typeof(localStorage) != 'undefined' && typeof(window) != 'undefined'
   const serializer = options?.serializer || JSON
 
   function updateStorage(key: string, value: T) {


### PR DESCRIPTION
I was using this with Astro and for some reason `localStorage` is defined but window of course isn't. This patches the `browser` variable by also checking for `window`