### PR TITLE
feat: Added option to choose storage type (support for sessionStorage)

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,9 +48,7 @@ import * as devalue from 'devalue';
 // Third parameter is options.
 export const preferences = writable('preferences', 'foo', {
   serializer: devalue // defaults to JSON
-  storage: {
-    type: 'session' // set to 'session' for sessionStorage, defaults to 'local'
-  }
+  storage: 'session' // set to 'session' for sessionStorage, defaults to 'local'
 })
 ```
 

--- a/README.md
+++ b/README.md
@@ -39,6 +39,21 @@ get(preferences) // read value
 $preferences // read value with automatic subscription
 ```
 
+Change serializer or storage type: 
+
+```javascript
+import { writable } from 'svelte-local-storage-store'
+import * as devalue from 'devalue';
+
+// Third parameter is options.
+export const preferences = writable('preferences', 'foo', {
+  serializer: devalue // defaults to JSON
+  storage: {
+    type: 'session' // set to 'session' for sessionStorage, defaults to 'local'
+  }
+})
+```
+
 ## License
 
 MIT

--- a/index.ts
+++ b/index.ts
@@ -15,9 +15,7 @@ type StorageType = 'local' | 'session'
 
 interface Options<T> {
   serializer?: Serializer<T>
-  storage?: {
-    type?: StorageType
-  }
+  storage?: StorageType
 }
 
 function getStorage(type: StorageType) {
@@ -26,7 +24,7 @@ function getStorage(type: StorageType) {
 
 export function writable<T>(key: string, initialValue: T, options?: Options<T>): Writable<T> {
   const serializer = options?.serializer ?? JSON
-  const storageType = options?.storage?.type ?? 'local'
+  const storageType = options?.storage ?? 'local'
   const browser = typeof(window) !== 'undefined' && typeof(document) !== 'undefined'
 
   function updateStorage(key: string, value: T) {

--- a/test/localStorageStore.test.ts
+++ b/test/localStorageStore.test.ts
@@ -209,7 +209,6 @@ describe('writable()', () => {
       })
 
       store.set('bar')  
-      console.log(sessionStorage)
 
       expect(window.sessionStorage.setItem).toHaveBeenCalled()  
   })

--- a/test/localStorageStore.test.ts
+++ b/test/localStorageStore.test.ts
@@ -195,4 +195,22 @@ describe('writable()', () => {
     expect(value).toEqual(testSet)
     expect(localStorage.myKey11).toEqual(serializer.stringify(testSet))
   })
+
+  it('lets you switch storage type', () => {
+      jest.spyOn(Object.getPrototypeOf(window.sessionStorage), 'setItem')
+      Object.setPrototypeOf(window.sessionStorage.setItem, jest.fn())
+
+      const value = 'foo'
+
+      const store = writable('myKey12', value, {
+        storage: {
+          type: 'session'
+        }
+      })
+
+      store.set('bar')  
+      console.log(sessionStorage)
+
+      expect(window.sessionStorage.setItem).toHaveBeenCalled()  
+  })
 })

--- a/test/localStorageStore.test.ts
+++ b/test/localStorageStore.test.ts
@@ -203,9 +203,7 @@ describe('writable()', () => {
       const value = 'foo'
 
       const store = writable('myKey12', value, {
-        storage: {
-          type: 'session'
-        }
+        storage: 'session'
       })
 
       store.set('bar')  


### PR DESCRIPTION
Added a property `storage.type` in the options object. Accepts values "local" and "session", defaults to "local".

Closes https://github.com/joshnuss/svelte-local-storage-store/issues/111