### PR TITLE
Rename writable function

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,11 +15,11 @@ npm install svelte-local-storage-store
 Define the store:
 
 ```javascript
-import { writable } from 'svelte-local-storage-store'
+import { persisted } from 'svelte-local-storage-store'
 
 // First param `preferences` is the local storage key.
 // Second param is the initial value.
-export const preferences = writable('preferences', {
+export const preferences = persisted('preferences', {
   theme: 'dark',
   pane: '50%',
   ...
@@ -45,7 +45,7 @@ You can also optionally set the `serializer` or `storage` type:
 import * as devalue from 'devalue'
 
 // third parameter is options.
-export const preferences = writable('local-storage-key', 'default-value', {
+export const preferences = persisted('local-storage-key', 'default-value', {
   serializer: devalue, // defaults to `JSON`
   storage: 'session' // 'session' for sessionStorage, defaults to 'local'
 })

--- a/index.ts
+++ b/index.ts
@@ -23,6 +23,10 @@ function getStorage(type: StorageType) {
 }
 
 export function writable<T>(key: string, initialValue: T, options?: Options<T>): Writable<T> {
+  console.warn("writable() has been deprecated. Please use persisted() instead.\n\nchange:\n\nimport { writable } from 'svelte-local-storage-store'\n\nto:\n\nimport { persisted } from 'svelte-local-storage-store'")
+  return persisted<T>(key, initialValue, options)
+}
+export function persisted<T>(key: string, initialValue: T, options?: Options<T>): Writable<T> {
   const serializer = options?.serializer ?? JSON
   const storageType = options?.storage ?? 'local'
   const browser = typeof(window) !== 'undefined' && typeof(document) !== 'undefined'

--- a/test/localStorageStore.test.ts
+++ b/test/localStorageStore.test.ts
@@ -1,11 +1,25 @@
-import { writable } from '../index'
+import { persisted, writable } from '../index'
 import { get } from 'svelte/store'
 
 beforeEach(() => localStorage.clear())
 
 describe('writable()', () => {
+  test('it works, but raises deprecation warning', () => {
+    console.warn = jest.fn()
+
+    localStorage.setItem('myKey2', '"existing"')
+
+    const store = writable('myKey2', 'initial')
+    const value = get(store)
+
+    expect(value).toEqual('existing')
+    expect(console.warn).toHaveBeenCalledWith(expect.stringMatching(/deprecated/))
+  })
+})
+
+describe('persisted()', () => {
   test('uses initial value if nothing in local storage', () => {
-    const store = writable('myKey', 123)
+    const store = persisted('myKey', 123)
     const value = get(store)
 
     expect(value).toEqual(123)
@@ -14,7 +28,7 @@ describe('writable()', () => {
   test('uses existing value if data already in local storage', () => {
     localStorage.setItem('myKey2', '"existing"')
 
-    const store = writable('myKey2', 'initial')
+    const store = persisted('myKey2', 'initial')
     const value = get(store)
 
     expect(value).toEqual('existing')
@@ -24,7 +38,7 @@ describe('writable()', () => {
     test('replaces old value', () => {
       localStorage.setItem('myKey3', '"existing"')
 
-      const store = writable('myKey3', '')
+      const store = persisted('myKey3', '')
       store.set('new-value')
       const value = get(store)
 
@@ -33,7 +47,7 @@ describe('writable()', () => {
     })
 
     test('adds new value', () => {
-      const store = writable('myKey4', '')
+      const store = persisted('myKey4', '')
       store.set('new-value')
       const value = get(store)
 
@@ -46,7 +60,7 @@ describe('writable()', () => {
     test('replaces old value', () => {
       localStorage.setItem('myKey5', '123')
 
-      const store = writable('myKey5', 0)
+      const store = persisted('myKey5', 0)
       store.update(n => n + 1)
       const value = get(store)
 
@@ -55,7 +69,7 @@ describe('writable()', () => {
     })
 
     test('adds new value', () => {
-      const store = writable('myKey6', 123)
+      const store = persisted('myKey6', 123)
       store.update(n => n + 1)
       const value = get(store)
 
@@ -66,7 +80,7 @@ describe('writable()', () => {
 
   describe('subscribe()', () => {
     it('publishes updates', () => {
-      const store = writable('myKey7', 123)
+      const store = persisted('myKey7', 123)
       const values: number[] = []
       const unsub = store.subscribe((value : number) => {
         if (value !== undefined) values.push(value)
@@ -81,7 +95,7 @@ describe('writable()', () => {
   })
 
   it('handles duplicate stores with the same key', () => {
-    const store1 = writable('same-key', 1)
+    const store1 = persisted('same-key', 1)
     const values1: number[] = []
 
     const unsub1 = store1.subscribe(value => {
@@ -90,7 +104,7 @@ describe('writable()', () => {
 
     store1.set(2)
 
-    const store2 = writable('same-key', 99)
+    const store2 = persisted('same-key', 99)
     const values2: number[] = []
 
     const unsub2 = store2.subscribe(value => {
@@ -114,7 +128,7 @@ describe('writable()', () => {
     type NumberDict = { [key: string] : number }
 
     it('sets storage when key matches', () => {
-      const store = writable('myKey8', {a: 1})
+      const store = persisted('myKey8', {a: 1})
       const values: NumberDict[] = []
 
       const unsub = store.subscribe((value: NumberDict) => {
@@ -130,7 +144,7 @@ describe('writable()', () => {
     })
 
     it('sets store to null when value is null', () => {
-      const store = writable('myKey9', {a: 1})
+      const store = persisted('myKey9', {a: 1})
       const values: NumberDict[] = []
 
       const unsub = store.subscribe((value: NumberDict) => {
@@ -146,7 +160,7 @@ describe('writable()', () => {
     })
 
     it("doesn't update store when key doesn't match", () => {
-      const store = writable('myKey10', 1)
+      const store = persisted('myKey10', 1)
       const values: number[] = []
 
       const unsub = store.subscribe((value: number) => {
@@ -162,7 +176,7 @@ describe('writable()', () => {
     })
 
     it("doesn't update store when there are no subscribers", () => {
-      const store = writable('myKey', 1)
+      const store = persisted('myKey', 1)
       const values: number[] = []
 
       const event = new StorageEvent('storage', {key: 'myKey', newValue: '2'})
@@ -187,7 +201,7 @@ describe('writable()', () => {
 
     const testSet = new Set([1, 2, 3])
 
-    const store = writable('myKey11', testSet, { serializer })
+    const store = persisted('myKey11', testSet, { serializer })
     const value = get(store)
 
     store.update(d => d.add(4))
@@ -202,7 +216,7 @@ describe('writable()', () => {
 
       const value = 'foo'
 
-      const store = writable('myKey12', value, {
+      const store = persisted('myKey12', value, {
         storage: 'session'
       })
 


### PR DESCRIPTION
Renames the `writable()` function to `persisted()`.
This is to avoid confusion with Svelte's built-in `writable`.

The old way is still supported, but it will raise a deprecation warning.
