### PR TITLE
fix: Only write changes

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -43,8 +43,6 @@ export function persisted<T>(key: string, initialValue: T, options?: Options<T>)
 
       if (json) {
         set(<T>serializer.parse(json))
-      } else {
-        updateStorage(key, initialValue)
       }
 
       if (browser) {

--- a/test/localStorageStore.test.ts
+++ b/test/localStorageStore.test.ts
@@ -23,7 +23,7 @@ describe('persisted()', () => {
     const value = get(store)
 
     expect(value).toEqual(123)
-    expect(localStorage.myKey).toEqual('123')
+    expect(localStorage.myKey).toBeUndefined()
   })
 
   test('uses existing value if data already in local storage', () => {


### PR DESCRIPTION
Reverts 80a57db37b4b5e67679df07b904e6f9ce0695fa4 

The value should only be written when changed. That feels like a better default option.

Closes #181
